### PR TITLE
Handle template loaders that don't implement get_template_sources

### DIFF
--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
                     if get_template_sources is None:
                         get_template_sources = loader.get_template_sources
                     paths.update(smart_text(origin) for origin in get_template_sources(''))
-                except (ImportError, AttributeError, TypeError):
+                except (ImportError, AttributeError, TypeError, NotImplementedError):
                     # Yeah, this didn't work out so well, let's move on
                     pass
 


### PR DESCRIPTION
The django-dbtemplates template loader still uses the django-1.8
`load_template_source` instead of the newer `get_template_sources`. This
change allows using django-compress and django-dbtemplates on the same
project.